### PR TITLE
fix(newsletter): remove unused ref from inputs

### DIFF
--- a/pages/newsletter.vue
+++ b/pages/newsletter.vue
@@ -23,7 +23,6 @@
         <div class="pt-3 pl-4 pr-4 mx-auto text-center md:w-1/2">
           <div class="mb-0 mb-4">
             <input
-              ref="name"
               v-model="email"
               type="text"
               class="
@@ -50,7 +49,6 @@
         <div class="pt-3 pl-4 pr-4 mx-auto text-center md:w-1/2">
           <div class="mb-4">
             <input
-              ref="name"
               v-model="name"
               type="text"
               class="


### PR DESCRIPTION
This allow Elon placeholder to display instead of html element

## From
<img width="613" alt="Screenshot 2021-10-09 at 13 25 03" src="https://user-images.githubusercontent.com/6470445/136656220-f462e2cf-3f06-447b-b646-f2d1f33682e8.png">

## To
<img width="742" alt="Screenshot 2021-10-09 at 13 30 48" src="https://user-images.githubusercontent.com/6470445/136656234-9fe3504e-e915-487d-9fd0-97c5a89265f0.png">

